### PR TITLE
Concatenate add.claims

### DIFF
--- a/R/fisherC.R
+++ b/R/fisherC.R
@@ -20,7 +20,7 @@ fisherC <- function(dTable, add.claims = NULL, direction = NULL, conserve = FALS
 
     if(!is.null(add.claims)) {
 
-      ps <- ps + add.claims
+      ps <- c(ps,add.claims)
 
       message("Fisher's C has been adjusted to include additional claims not shown in the tests of directed separation.")
 


### PR DESCRIPTION
Concatenates add.claims vector to ps vector, rather than adding. Currently returns a warning if length(add.claims)!=length(ps):

Warning message:
In ps + add.claims :
  longer object length is not a multiple of shorter object length