### PR TITLE
Sarlm support

### DIFF
--- a/R/coefs.R
+++ b/R/coefs.R
@@ -174,7 +174,7 @@ getCoefficients <- function(model, data = NULL, test.statistic = "F", test.type 
 
   if(any(class(model) %in% c("lmerMod"))) ret <- getAnova(model)
 
-  if(all(class(model) %in% c("sarlm"))) {
+  if(all(class(model) %in% c("sarlm", "Sarlm"))) {
 
     ret <- as.data.frame(summary(model)$Coef)
 
@@ -479,7 +479,7 @@ GetSDy <- function(model, data, standardize = "scale", standardize.type = "laten
 
   if(class(family.) == "try-error") family. <- try(model$family, silent = TRUE)
 
-  if(class(family.) == "try-error" | is.null(family.) & all(class(model) %in% c("sarlm", "gls", "lme")))
+  if(class(family.) == "try-error" | is.null(family.) & all(class(model) %in% c("sarlm", "Sarlm", "gls", "lme")))
 
     family. <- list(family = "gaussian", link = "identity")
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -306,6 +306,10 @@ GetSingleData <- function(model) {
          "sarlm" = {
            dat <- eval(getCall(model)$data, environment(formula(model)))
          },
+         
+         "Sarlm" = {
+           dat <- eval(getCall(model)$data, environment(formula(model)))
+         },
 
          "glm" = {
            dat <- model$data
@@ -539,7 +543,7 @@ listFormula <- function(modelList, formulas = 0) {
 #' 
 #' @keywords internal
 #' 
-nObs <- function(object, ...) if(any(class(object) %in% c("phylolm", "phyloglm", "sarlm"))) length(fitted(object)) else nobs(object, ...)
+nObs <- function(object, ...) if(any(class(object) %in% c("phylolm", "phyloglm", "sarlm", "Sarlm"))) length(fitted(object)) else nobs(object, ...)
 
 #' Get random effects from merMod
 #' 

--- a/R/piecewiseSEM-package.R
+++ b/R/piecewiseSEM-package.R
@@ -6,8 +6,8 @@
 #' Compared with traditional variance-covariance based SEM, piecewise SEM
 #' allows for fitting of models to different distributions through GLM and/or
 #' hierarchical/nested random structures through (G)LMER. Supported model
-#' classes include: \code{lm, glm, gls, pgls, sarlm, lme, glmmPQL, lmerMod,
-#' merModLmerTest, glmerMod}.
+#' classes include: \code{lm, glm, gls, pgls, sarlm, Sarlm, lme, glmmPQL,
+#' lmerMod, merModLmerTest, glmerMod}.
 #'
 #' \tabular{ll}{ Package: \tab piecewiseSEM\cr Type: \tab Package\cr Version:
 #' \tab 2.1.1\cr Date: \tab 2020-04-20\cr Depends: \tab R (>= 3.5.0), nlme,

--- a/R/psem.R
+++ b/R/psem.R
@@ -4,7 +4,7 @@
 #' structural equation model.
 #'
 #' \code{psem} takes a list of structural equations, which can be model objects
-#' of classes: \code{lm, glm, gls, pgls, sarlm, lme, glmmPQL, lmerMod,
+#' of classes: \code{lm, glm, gls, pgls, sarlm, Sarlm, lme, glmmPQL, lmerMod,
 #' lmerModLmerTest, glmerMod}.
 #'
 #' It also takes objects of class \code{formula, formula.cerror}, corresponding
@@ -143,7 +143,7 @@ evaluateClasses <- function(modelList) {
     "lm", "glm", "gls", "negbin",
     "lme", "glmmPQL",
     "lmerMod", "lmerModLmerTest", "glmerMod",
-    "sarlm",
+    "sarlm","Sarlm",
     "pgls", "phylolm", "phyloglm"
   )
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This version is a major update to the `piecewiseSEM` package that uses a complet
 
 It also incorporates new functionality in the form of coefficient standardization and updated methods for R^2 for mixed models.
 
-Currently supported model classes: `lm, glm, gls, pgls, sarlm, lme, glmmPQL, lmerMod, merModLmerTest, glmerMod`
+Currently supported model classes: `lm, glm, gls, pgls, sarlm, Sarlm, lme, glmmPQL, lmerMod, merModLmerTest, glmerMod`
 
 ## To add a new model class
 Frequently, we get requests to add new model classes. We'd like to accommodate wherever we can! Currently, to add a new model class, you will need to update the following functions in the following files:  


### PR DESCRIPTION
Just add support for the change of class name: from sarlm to Sarlm in spatialreg package (see NEWS in version 1.1-8 https://cran.r-project.org/web/packages/spatialreg/news/news.html ).
I only added "Sarlm" in the code right besides original "sarlm", hoping that Sarlm can be used in the same way as sarlm (it looks like that) and that sarlm is already correctly supported.
It is related to issue https://github.com/jslefche/piecewiseSEM/issues/247 