### PR TITLE
Fix typo in anovaTable()

### DIFF
--- a/R/anova_psem.R
+++ b/R/anova_psem.R
@@ -92,7 +92,7 @@ anovaTable <- function(object, anovafun = "Anova", digits = 3) {
     
     DF <- ifelse(any(grepl("numDF", colnames(dat))), dat$numDF, dat$Df)
     
-    Test.Stat <- ifelse(any(grepl("F value", colnames(dat))), dat$`F-value`, dat[, 1])
+    Test.Stat <- ifelse(any(grepl("F value", colnames(dat))), dat$`F value`, ifelse(any(grepl("F-value", colnames(dat))), dat$`F-value`, dat[, 1]))
     
     ret <- data.frame(
       Response = response,

--- a/R/anova_psem.R
+++ b/R/anova_psem.R
@@ -92,7 +92,7 @@ anovaTable <- function(object, anovafun = "Anova", digits = 3) {
     
     DF <- ifelse(any(grepl("numDF", colnames(dat))), dat$numDF, dat$Df)
     
-    Test.Stat <- ifelse(any(grepl("F-value", colnames(dat))), dat$`F-value`, dat[, 1])
+    Test.Stat <- ifelse(any(grepl("F value", colnames(dat))), dat$`F-value`, dat[, 1])
     
     ret <- data.frame(
       Response = response,


### PR DESCRIPTION
It checked for a column named "F-value", but the table from `car::Anova()` is named "F value". This resulted in all F statistics from the same model being reported incorrectly as the first sums of squares value. 

This PR fixes this, though a more robust solution (e.g., when is the first value of the table actually the correct value to report) might be preferred.