### PR TITLE
Add test.statistic and test.type argument to getAnova() inside of getCoefficients()

### DIFF
--- a/R/coefs.R
+++ b/R/coefs.R
@@ -178,7 +178,7 @@ getCoefficients <- function(model, data = NULL, test.statistic = "F", test.type 
       
       # krp <- KRp(model, vars[-1], data, intercepts = TRUE)
   
-      ret <- getAnova(model)
+      ret <- getAnova(model, test.statistic = test.statistic, test.type = test.type)
       
       # ret <- cbind(ret[, 1:2], DF = nobs(model), ret[, 3], P.Value = NA)
       


### PR DESCRIPTION
This PR addresses issue #305 but only for the specific case where all submodels are of class `lmerMod`.

The `coefs()` function includes arguments `test.statistic` and `test.type`. But currently, those two arguments are not doing anything. They are intended to be arguments to `car::Anova()`, passed via `getAnova()`, but they are not passed all the way through to `getAnova()`. As a result, `car::Anova()` never "sees" them, and changing them has no effect, even if invalid values are input.

The small correction I made here to the `getCoefficients()` function passes the user-specified arguments to `getAnova()`, but only when `all(class(model) %in% c("lmerMod"))` is true. Therefore it has the desired result for `lmer` models but does nothing otherwise. I would recommend noting that in the documentation of `coefs`: specifying that `test.statistic` and `test.type` arguments will only have an effect if the models are `lmerMod`.

Thanks for your great package and thanks for your attention to this PR!